### PR TITLE
Update GetArtefacts_config.xml

### DIFF
--- a/config/GetArtefacts_config.xml
+++ b/config/GetArtefacts_config.xml
@@ -5,9 +5,9 @@
     <samples MaxTotalBytes="1GB" MaxSampleCount="200000" MaxPerSampleBytes="650MB">
         <sample name="Inf" MaxPerSampleBytes="1MB">
           <ntfs_find name_match="*.inf"/>
-          <ntfs_exclude path_match="\Windows\*"/>
-          <ntfs_exclude path_match="\Program Files\*"/>
-          <ntfs_exclude path_match="\Program Files (x86)\*"/>
+          <ntfs_exclude path_match="\Windows\*.inf"/>
+          <ntfs_exclude path_match="\Program Files\*.inf"/>
+          <ntfs_exclude path_match="\Program Files (x86)\*.inf"/>
         </sample>
         <sample name="Prefetch" MaxPerSampleBytes="20MB">
             <ntfs_find path_match="\Windows\Prefetch\*.pf"/>


### PR DESCRIPTION
Hello,

The ntfs_exclude is global to the configuration file. If you don't filter the exclusion only on *.inf you won't collect others artefacts in these directories (like Prefetch for example).
I have just updated my configuration files, feel free too pick them.

Regards,